### PR TITLE
Add GraphQL article link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,6 +1137,8 @@ watch: {
 
 ### GraphQL
 
+* [Basics of GraphQL with Vue.js](https://medium.com/@lachlanmiller_52885/graphql-basics-and-practical-examples-with-vue-6b649b9685e0)
+
 ---
 
 ### Misc


### PR DESCRIPTION
I noticed there isn't any GraphQL links, so I added a link to an article about basic GraphQL with Vue.